### PR TITLE
Handling returning value false from file_get_contents()

### DIFF
--- a/src/Exception/ConnectException.php
+++ b/src/Exception/ConnectException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Salamek\Zasilkovna\Exception;
+
+final class ConnectException extends \Exception
+{
+}


### PR DESCRIPTION
Solving: Type error: Salamek\Zasilkovna\ApiRest::post(): Return value must be of type string, bool returned.